### PR TITLE
Add datalabels plugin and toggle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.0.8",
         "chart.js": "^4.4.8",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "html2canvas": "^1.4.1",
         "lodash.throttle": "^4.1.1",
         "react": "^19.0.0",
@@ -2077,6 +2078,15 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/clsx": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.0.8",
     "chart.js": "^4.4.8",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "html2canvas": "^1.4.1",
     "lodash.throttle": "^4.1.1",
     "react": "^19.0.0",

--- a/frontend/src/components/BivariateChart.jsx
+++ b/frontend/src/components/BivariateChart.jsx
@@ -2,7 +2,10 @@ import { useEffect, useState, useRef, useLayoutEffect } from "react";
 import useBivariateData from "../hooks/useBivariateData";
 import useChartExport from "../hooks/useChartExport";
 import Chart from 'chart.js/auto';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 import ChartControls from "./charts/ChartControls";
+
+Chart.register(ChartDataLabels);
 import { getFormattedDate } from "../utils/chartExport";
 import useAvailableSpace from "../hooks/useAvailableSpace";
 
@@ -41,6 +44,7 @@ export default function BivariateChart({
   // State variables for chart display
   const [aspectRatio, setAspectRatio] = useState(windowWidth < 640 ? 1.2 : 1.6);
   const [showLegend, setShowLegend] = useState(true);
+  const [showLabels, setShowLabels] = useState(false);
   const [zoom, setZoom] = useState(100);
   const [isFullscreen, setIsFullscreen] = useState(false);
   // Add download format state
@@ -252,6 +256,7 @@ export default function BivariateChart({
     aspectRatio,
     zoom,
     showLegend,
+    showLabels,
     chartHeight
   ]);
 
@@ -293,10 +298,19 @@ export default function BivariateChart({
   // Add legend toggle function
   const toggleLegend = () => {
     setShowLegend(!showLegend);
-    
+
     // Update chart if it exists
     if (chartInstance) {
       chartInstance.options.plugins.legend.display = !showLegend;
+      chartInstance.update();
+    }
+  };
+
+  const toggleLabels = () => {
+    setShowLabels(!showLabels);
+
+    if (chartInstance) {
+      chartInstance.options.plugins.datalabels.display = !showLabels;
       chartInstance.update();
     }
   };
@@ -484,6 +498,16 @@ export default function BivariateChart({
                 size: windowWidth < 640 ? 10 : 12
               }
             }
+          },
+          datalabels: {
+            display: showLabels,
+            color: darkMode ? '#e5e7eb' : '#374151',
+            anchor: 'end',
+            align: 'top',
+            font: {
+              size: windowWidth < 640 ? 10 : 12
+            },
+            formatter: (value) => value.toLocaleString()
           }
         },
         scales: {
@@ -584,7 +608,8 @@ export default function BivariateChart({
       excludedValues2,
       zoom: zoom,
       aspectRatio: aspectRatio,
-      showLegend: showLegend
+      showLegend: showLegend,
+      showLabels: showLabels
     });
   };
 
@@ -634,8 +659,8 @@ export default function BivariateChart({
         <div 
           ref={localChartContainer}
           className={`relative overflow-hidden rounded-lg ${
-            isFullscreen 
-              ? 'bg-black w-screen h-screen flex items-center justify-center' 
+            isFullscreen
+              ? `${darkMode ? 'bg-gray-800' : 'bg-white'} w-screen h-screen flex items-center justify-center`
               : `${darkMode ? 'bg-gray-800/30' : 'bg-gray-50/50'} p-2 sm:p-4`
           }`}
           style={{ 
@@ -693,6 +718,8 @@ export default function BivariateChart({
                 resetZoom={resetZoom}
                 showLegend={showLegend}
                 toggleLegend={toggleLegend}
+                showLabels={showLabels}
+                toggleLabels={toggleLabels}
                 toggleAspectRatio={toggleAspectRatio}
                 toggleFullscreen={toggleFullscreen}
                 isFullscreen={isFullscreen}

--- a/frontend/src/components/ChartComponent.jsx
+++ b/frontend/src/components/ChartComponent.jsx
@@ -2,6 +2,10 @@ import { useEffect, useState, useRef, useLayoutEffect } from "react";
 import { getDistribucion } from "../api/cisApi";
 import { API_URL } from "../api/cisApi";
 import Chart from 'chart.js/auto';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
+
+// Register plugin once
+Chart.register(ChartDataLabels);
 import { getFormattedDate } from "../utils/chartExport";
 import ChartControls from "./charts/ChartControls";
 import useChartExport from "../hooks/useChartExport";
@@ -27,6 +31,7 @@ export default function ChartComponent({
   const [zoom, setZoom] = useState(initialZoom);
   const [aspectRatio, setAspectRatio] = useState(initialAspectRatio);
   const [showLegend, setShowLegend] = useState(initialShowLegend);
+  const [showLabels, setShowLabels] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [totalExcluded, setTotalExcluded] = useState(0);
   const [downloadFormat, setDownloadFormat] = useState('png');
@@ -40,7 +45,12 @@ export default function ChartComponent({
   const [chartOptions, setChartOptions] = useState({
     animation: true,
     responsive: true,
-    aspectRatio: initialAspectRatio
+    aspectRatio: initialAspectRatio,
+    plugins: {
+      datalabels: {
+        display: false
+      }
+    }
   });
   const [chartInitialized, setChartInitialized] = useState(false);
 
@@ -114,7 +124,8 @@ export default function ChartComponent({
       darkMode: darkMode,
       zoom: zoom,
       aspectRatio: aspectRatio,
-      showLegend: showLegend
+      showLegend: showLegend,
+      showLabels: showLabels
     });
   };
 
@@ -335,7 +346,13 @@ export default function ChartComponent({
         
         // Update legend display
         chartInstance.options.plugins.legend.display = showLegend && (chartType === 'pie' || chartType === 'doughnut');
-        
+        // Update datalabels options
+        if (chartInstance.options.plugins.datalabels) {
+          chartInstance.options.plugins.datalabels.display = showLabels;
+          chartInstance.options.plugins.datalabels.color = darkMode ? '#e5e7eb' : '#374151';
+          chartInstance.options.plugins.datalabels.font.size = windowWidth < 640 ? 10 : 12;
+        }
+
         // Apply the updates
         chartInstance.update();
         return;
@@ -449,6 +466,16 @@ export default function ChartComponent({
               }
             }
           },
+          datalabels: {
+            display: showLabels,
+            color: darkMode ? '#e5e7eb' : '#374151',
+            anchor: 'end',
+            align: 'top',
+            font: {
+              size: windowWidth < 640 ? 10 : 12
+            },
+            formatter: (value) => value.toLocaleString()
+          },
           tooltip: {
             callbacks: {
               label: function(context) {
@@ -495,7 +522,7 @@ export default function ChartComponent({
       setChartInitialized(true);
     }, 0);
     
-  }, [variable, chartType, sortOrder, excludedValues, data, valueLabels, loading, darkMode, showLegend]);
+  }, [variable, chartType, sortOrder, excludedValues, data, valueLabels, loading, darkMode, showLegend, showLabels]);
 
   // Separate effect for handling resize and zoom changes
   useEffect(() => {
@@ -524,6 +551,12 @@ export default function ChartComponent({
         chartInstance.options.plugins.legend.labels.padding = windowWidth < 640 ? 8 : 15;
         chartInstance.options.plugins.legend.labels.font.size = windowWidth < 640 ? 10 : 12;
       }
+
+      if (chartInstance.options.plugins && chartInstance.options.plugins.datalabels) {
+        chartInstance.options.plugins.datalabels.font.size = windowWidth < 640 ? 10 : 12;
+        chartInstance.options.plugins.datalabels.color = darkMode ? '#e5e7eb' : '#374151';
+        chartInstance.options.plugins.datalabels.display = showLabels;
+      }
       
       // Apply gradient colors again if needed
       applyGradientColors(chartInstance);
@@ -532,7 +565,7 @@ export default function ChartComponent({
       chartInstance.resize();
       chartInstance.update();
     }
-  }, [windowWidth, windowHeight, chartHeight, zoom, aspectRatio, isPortrait, chartInitialized]);
+  }, [windowWidth, windowHeight, chartHeight, zoom, aspectRatio, isPortrait, chartInitialized, showLabels, darkMode]);
 
   useEffect(() => {
     const handleFullscreenChange = () => {
@@ -687,7 +720,7 @@ export default function ChartComponent({
         ref={chartContainer}
         className={`relative group overflow-hidden rounded-lg shadow-lg transition-all ${
           isFullscreen
-            ? 'bg-black w-screen h-screen flex items-center justify-center'
+            ? `${darkMode ? 'bg-gray-800' : 'bg-white'} w-screen h-screen flex items-center justify-center`
             : `${darkMode ? 'bg-gradient-to-br from-gray-800 to-gray-700' : 'bg-gradient-to-br from-white to-gray-100'} p-2 sm:p-4`
         }`}
         style={{ 
@@ -745,6 +778,8 @@ export default function ChartComponent({
               resetZoom={resetZoom}
               showLegend={showLegend}
               toggleLegend={() => setShowLegend(!showLegend)}
+              showLabels={showLabels}
+              toggleLabels={() => setShowLabels(!showLabels)}
               toggleAspectRatio={toggleAspectRatio}
               toggleFullscreen={toggleFullscreen}
               isFullscreen={isFullscreen}

--- a/frontend/src/components/charts/ChartControls.jsx
+++ b/frontend/src/components/charts/ChartControls.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 /**
  * Componente para los controles de interacción con los gráficos
@@ -17,6 +16,8 @@ import React from 'react';
  * @param {Function} props.resetZoom - Función para resetear el zoom
  * @param {boolean} props.showLegend - Si se muestra la leyenda
  * @param {Function} props.toggleLegend - Función para mostrar/ocultar la leyenda
+ * @param {boolean} props.showLabels - Si se muestran las etiquetas de datos
+ * @param {Function} props.toggleLabels - Función para mostrar/ocultar las etiquetas
  * @param {Function} props.toggleAspectRatio - Función para cambiar la relación de aspecto
  * @param {Function} props.toggleFullscreen - Función para alternar pantalla completa
  * @param {boolean} props.isFullscreen - Si el gráfico está en pantalla completa
@@ -36,6 +37,8 @@ const ChartControls = ({
   resetZoom,
   showLegend,
   toggleLegend,
+  showLabels,
+  toggleLabels,
   toggleAspectRatio,
   toggleFullscreen,
   isFullscreen = false,
@@ -137,6 +140,18 @@ const ChartControls = ({
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            </svg>
+          </button>
+        )}
+
+        {toggleLabels && (
+          <button
+            onClick={toggleLabels}
+            className={`p-1 rounded ${darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'} transition-colors`}
+            title={showLabels ? "Ocultar valores" : "Mostrar valores"}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 6h16M4 12h16M4 18h7" />
             </svg>
           </button>
         )}


### PR DESCRIPTION
## Summary
- allow chart labels to be toggled in ChartComponent and BivariateChart
- register `chartjs-plugin-datalabels`
- expose label toggle button in `ChartControls`
- keep fullscreen charts' background light instead of black

## Testing
- `npm run lint --prefix frontend` *(fails: many pre‑existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850747c6b00832db19fcd58622f2ac9