### PR TITLE
Add percentage view and fix chart type switch

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.0.8",
         "chart.js": "^4.4.8",
+        "chartjs-plugin-datalabels": "^2.2.0",
         "html2canvas": "^1.4.1",
         "lodash.throttle": "^4.1.1",
         "react": "^19.0.0",
@@ -2077,6 +2078,15 @@
       },
       "engines": {
         "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-plugin-datalabels": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
+      "integrity": "sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=3.0.0"
       }
     },
     "node_modules/clsx": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.0.8",
     "chart.js": "^4.4.8",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "html2canvas": "^1.4.1",
     "lodash.throttle": "^4.1.1",
     "react": "^19.0.0",

--- a/frontend/src/components/AnalysisPage.jsx
+++ b/frontend/src/components/AnalysisPage.jsx
@@ -481,12 +481,13 @@ export default function AnalysisPage() {
                         <div className={`p-4 rounded-lg ${darkMode ? 'bg-gray-700' : 'bg-gray-50'} mb-4`}>
                           <h4 className="font-medium mb-3">Gráfico</h4>
                           <div className="overflow-hidden chart-container" style={{ maxHeight: 'calc(100vh - 250px)' }}>
-                            <ChartComponent 
-                              variable={selectedVariable.code} 
-                              chartType={chartType} 
-                              sortOrder={sortOrder} 
+                            <ChartComponent
+                              variable={selectedVariable.code}
+                              chartType={chartType}
+                              sortOrder={sortOrder}
                               excludedValues={excludedPrimaryValues}
                               darkMode={darkMode}
+                              onChangeChartType={setChartType}
                             />
                           </div>
                         </div>

--- a/frontend/src/components/BivariateChart.jsx
+++ b/frontend/src/components/BivariateChart.jsx
@@ -2,7 +2,10 @@ import { useEffect, useState, useRef, useLayoutEffect } from "react";
 import useBivariateData from "../hooks/useBivariateData";
 import useChartExport from "../hooks/useChartExport";
 import Chart from 'chart.js/auto';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
 import ChartControls from "./charts/ChartControls";
+
+Chart.register(ChartDataLabels);
 import { getFormattedDate } from "../utils/chartExport";
 import useAvailableSpace from "../hooks/useAvailableSpace";
 
@@ -41,6 +44,7 @@ export default function BivariateChart({
   // State variables for chart display
   const [aspectRatio, setAspectRatio] = useState(windowWidth < 640 ? 1.2 : 1.6);
   const [showLegend, setShowLegend] = useState(true);
+  const [showLabels, setShowLabels] = useState(false);
   const [zoom, setZoom] = useState(100);
   const [isFullscreen, setIsFullscreen] = useState(false);
   // Add download format state
@@ -252,6 +256,7 @@ export default function BivariateChart({
     aspectRatio,
     zoom,
     showLegend,
+    showLabels,
     chartHeight
   ]);
 
@@ -293,10 +298,19 @@ export default function BivariateChart({
   // Add legend toggle function
   const toggleLegend = () => {
     setShowLegend(!showLegend);
-    
+
     // Update chart if it exists
     if (chartInstance) {
       chartInstance.options.plugins.legend.display = !showLegend;
+      chartInstance.update();
+    }
+  };
+
+  const toggleLabels = () => {
+    setShowLabels(!showLabels);
+
+    if (chartInstance) {
+      chartInstance.options.plugins.datalabels.display = !showLabels;
       chartInstance.update();
     }
   };
@@ -484,6 +498,19 @@ export default function BivariateChart({
                 size: windowWidth < 640 ? 10 : 12
               }
             }
+          },
+          datalabels: {
+            display: showLabels,
+            color: darkMode ? '#e5e7eb' : '#374151',
+            anchor: 'end',
+            align: 'top',
+            font: {
+              size: windowWidth < 640 ? 10 : 12
+            },
+            formatter: (value) =>
+              localViewMode === 'relative'
+                ? `${value.toFixed(1)}%`
+                : value.toLocaleString()
           }
         },
         scales: {
@@ -584,7 +611,8 @@ export default function BivariateChart({
       excludedValues2,
       zoom: zoom,
       aspectRatio: aspectRatio,
-      showLegend: showLegend
+      showLegend: showLegend,
+      showLabels: showLabels
     });
   };
 
@@ -634,8 +662,8 @@ export default function BivariateChart({
         <div 
           ref={localChartContainer}
           className={`relative overflow-hidden rounded-lg ${
-            isFullscreen 
-              ? 'bg-black w-screen h-screen flex items-center justify-center' 
+            isFullscreen
+              ? `${darkMode ? 'bg-gray-800' : 'bg-white'} w-screen h-screen flex items-center justify-center`
               : `${darkMode ? 'bg-gray-800/30' : 'bg-gray-50/50'} p-2 sm:p-4`
           }`}
           style={{ 
@@ -693,6 +721,8 @@ export default function BivariateChart({
                 resetZoom={resetZoom}
                 showLegend={showLegend}
                 toggleLegend={toggleLegend}
+                showLabels={showLabels}
+                toggleLabels={toggleLabels}
                 toggleAspectRatio={toggleAspectRatio}
                 toggleFullscreen={toggleFullscreen}
                 isFullscreen={isFullscreen}

--- a/frontend/src/components/ChartComponent.jsx
+++ b/frontend/src/components/ChartComponent.jsx
@@ -2,22 +2,27 @@ import { useEffect, useState, useRef, useLayoutEffect } from "react";
 import { getDistribucion } from "../api/cisApi";
 import { API_URL } from "../api/cisApi";
 import Chart from 'chart.js/auto';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
+
+// Register plugin once
+Chart.register(ChartDataLabels);
 import { getFormattedDate } from "../utils/chartExport";
 import ChartControls from "./charts/ChartControls";
 import useChartExport from "../hooks/useChartExport";
 import useAvailableSpace from "../hooks/useAvailableSpace";
 import { getChartColors } from "../utils/colorUtils";
 
-export default function ChartComponent({ 
-  variable, 
-  chartType = 'bar', 
-  sortOrder = 'code', 
+export default function ChartComponent({
+  variable,
+  chartType = 'bar',
+  sortOrder = 'code',
   excludedValues = [],
   darkMode = false,
   isFullscreenPage = false,
   initialZoom = 100,
   initialAspectRatio = 1.6,
-  initialShowLegend = true
+  initialShowLegend = true,
+  onChangeChartType
 }) {
   const [data, setData] = useState({});
   const [valueLabels, setValueLabels] = useState({});
@@ -27,6 +32,8 @@ export default function ChartComponent({
   const [zoom, setZoom] = useState(initialZoom);
   const [aspectRatio, setAspectRatio] = useState(initialAspectRatio);
   const [showLegend, setShowLegend] = useState(initialShowLegend);
+  const [showLabels, setShowLabels] = useState(false);
+  const [viewMode, setViewMode] = useState('absolute');
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [totalExcluded, setTotalExcluded] = useState(0);
   const [downloadFormat, setDownloadFormat] = useState('png');
@@ -40,7 +47,12 @@ export default function ChartComponent({
   const [chartOptions, setChartOptions] = useState({
     animation: true,
     responsive: true,
-    aspectRatio: initialAspectRatio
+    aspectRatio: initialAspectRatio,
+    plugins: {
+      datalabels: {
+        display: false
+      }
+    }
   });
   const [chartInitialized, setChartInitialized] = useState(false);
 
@@ -114,7 +126,9 @@ export default function ChartComponent({
       darkMode: darkMode,
       zoom: zoom,
       aspectRatio: aspectRatio,
-      showLegend: showLegend
+      showLegend: showLegend,
+      showLabels: showLabels,
+      viewMode: viewMode
     });
   };
 
@@ -311,10 +325,16 @@ export default function ChartComponent({
         });
         
         const values = processedData.map(([, value]) => value);
-        
+        const dataValues = viewMode === 'relative'
+          ? (() => {
+              const total = values.reduce((sum, v) => sum + v, 0);
+              return values.map(v => total ? (v / total) * 100 : 0);
+            })()
+          : values;
+
         // Update chart data without recreating
         chartInstance.data.labels = labels;
-        chartInstance.data.datasets[0].data = values;
+        chartInstance.data.datasets[0].data = dataValues;
         
         // Update chart type if needed
         chartInstance.config.type = chartType;
@@ -335,7 +355,15 @@ export default function ChartComponent({
         
         // Update legend display
         chartInstance.options.plugins.legend.display = showLegend && (chartType === 'pie' || chartType === 'doughnut');
-        
+        // Update datalabels options
+        if (chartInstance.options.plugins.datalabels) {
+          chartInstance.options.plugins.datalabels.display = showLabels;
+          chartInstance.options.plugins.datalabels.color = darkMode ? '#e5e7eb' : '#374151';
+          chartInstance.options.plugins.datalabels.font.size = windowWidth < 640 ? 10 : 12;
+          chartInstance.options.plugins.datalabels.formatter = (value) =>
+            viewMode === 'relative' ? `${value.toFixed(1)}%` : value.toLocaleString();
+        }
+
         // Apply the updates
         chartInstance.update();
         return;
@@ -391,7 +419,12 @@ export default function ChartComponent({
         labels,
         datasets: [{
           label: `${variable}`,
-          data: values,
+          data: viewMode === 'relative'
+            ? (() => {
+                const total = values.reduce((sum, v) => sum + v, 0);
+                return values.map(v => total ? (v / total) * 100 : 0);
+              })()
+            : values,
           backgroundColor: chartType === 'line' ? baseColors[0] : colors,
           borderColor: chartType === 'line' ? baseColors[0] : colors,
           borderWidth: 1,
@@ -427,6 +460,7 @@ export default function ChartComponent({
           },
           y: {
             beginAtZero: true,
+            suggestedMax: viewMode === 'relative' ? 100 : undefined,
             grid: {
               color: darkMode ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 0, 0, 0.05)'
             },
@@ -449,10 +483,26 @@ export default function ChartComponent({
               }
             }
           },
+          datalabels: {
+            display: showLabels,
+            color: darkMode ? '#e5e7eb' : '#374151',
+            anchor: 'end',
+            align: 'top',
+            font: {
+              size: windowWidth < 640 ? 10 : 12
+            },
+            formatter: (value) =>
+              viewMode === 'relative'
+                ? `${value.toFixed(1)}%`
+                : value.toLocaleString()
+          },
           tooltip: {
             callbacks: {
               label: function(context) {
                 const value = context.raw;
+                if (viewMode === 'relative') {
+                  return `${value.toFixed(1)}%`;
+                }
                 const total = context.chart.data.datasets[0].data.reduce((sum, val) => sum + val, 0);
                 const percentage = Math.round((value / total) * 100);
                 return `${value.toLocaleString()} (${percentage}%)`;
@@ -495,7 +545,7 @@ export default function ChartComponent({
       setChartInitialized(true);
     }, 0);
     
-  }, [variable, chartType, sortOrder, excludedValues, data, valueLabels, loading, darkMode, showLegend]);
+  }, [variable, chartType, sortOrder, excludedValues, data, valueLabels, loading, darkMode, showLegend, showLabels, viewMode]);
 
   // Separate effect for handling resize and zoom changes
   useEffect(() => {
@@ -517,12 +567,21 @@ export default function ChartComponent({
       }
       if (chartInstance.options.scales && chartInstance.options.scales.y) {
         chartInstance.options.scales.y.ticks.font.size = windowWidth < 640 ? 10 : 12;
+        chartInstance.options.scales.y.suggestedMax = viewMode === 'relative' ? 100 : undefined;
       }
       
       // Update legend font size
       if (chartInstance.options.plugins && chartInstance.options.plugins.legend) {
         chartInstance.options.plugins.legend.labels.padding = windowWidth < 640 ? 8 : 15;
         chartInstance.options.plugins.legend.labels.font.size = windowWidth < 640 ? 10 : 12;
+      }
+
+      if (chartInstance.options.plugins && chartInstance.options.plugins.datalabels) {
+        chartInstance.options.plugins.datalabels.font.size = windowWidth < 640 ? 10 : 12;
+        chartInstance.options.plugins.datalabels.color = darkMode ? '#e5e7eb' : '#374151';
+        chartInstance.options.plugins.datalabels.display = showLabels;
+        chartInstance.options.plugins.datalabels.formatter = (value) =>
+          viewMode === 'relative' ? `${value.toFixed(1)}%` : value.toLocaleString();
       }
       
       // Apply gradient colors again if needed
@@ -532,7 +591,7 @@ export default function ChartComponent({
       chartInstance.resize();
       chartInstance.update();
     }
-  }, [windowWidth, windowHeight, chartHeight, zoom, aspectRatio, isPortrait, chartInitialized]);
+  }, [windowWidth, windowHeight, chartHeight, zoom, aspectRatio, isPortrait, chartInitialized, showLabels, darkMode, viewMode]);
 
   useEffect(() => {
     const handleFullscreenChange = () => {
@@ -687,7 +746,7 @@ export default function ChartComponent({
         ref={chartContainer}
         className={`relative group overflow-hidden rounded-lg shadow-lg transition-all ${
           isFullscreen
-            ? 'bg-black w-screen h-screen flex items-center justify-center'
+            ? `${darkMode ? 'bg-gray-800' : 'bg-white'} w-screen h-screen flex items-center justify-center`
             : `${darkMode ? 'bg-gradient-to-br from-gray-800 to-gray-700' : 'bg-gradient-to-br from-white to-gray-100'} p-2 sm:p-4`
         }`}
         style={{ 
@@ -709,7 +768,13 @@ export default function ChartComponent({
             <select
               className={`text-xs p-1 rounded border w-full sm:w-auto min-w-[120px] ${darkMode ? 'bg-gray-800 border-gray-700 text-white' : 'bg-white border-gray-300 text-gray-700'}`}
               value={chartType}
-              onChange={(e) => window.location.href = `?variable=${variable}&chartType=${e.target.value}&sortOrder=${sortOrder}`}
+              onChange={(e) => {
+                if (onChangeChartType) {
+                  onChangeChartType(e.target.value);
+                } else {
+                  window.location.href = `?variable=${variable}&chartType=${e.target.value}&sortOrder=${sortOrder}`;
+                }
+              }}
               aria-label="Tipo de gráfico"
             >
               <option value="bar">Barras</option>
@@ -745,10 +810,14 @@ export default function ChartComponent({
               resetZoom={resetZoom}
               showLegend={showLegend}
               toggleLegend={() => setShowLegend(!showLegend)}
+              showLabels={showLabels}
+              toggleLabels={() => setShowLabels(!showLabels)}
+              viewMode={viewMode}
+              setViewMode={setViewMode}
               toggleAspectRatio={toggleAspectRatio}
               toggleFullscreen={toggleFullscreen}
               isFullscreen={isFullscreen}
-              hideViewModeSelector={true}
+              hideViewModeSelector={false}
             />
           </div>
         </div>

--- a/frontend/src/components/charts/ChartControls.jsx
+++ b/frontend/src/components/charts/ChartControls.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 /**
  * Componente para los controles de interacción con los gráficos
@@ -17,6 +16,8 @@ import React from 'react';
  * @param {Function} props.resetZoom - Función para resetear el zoom
  * @param {boolean} props.showLegend - Si se muestra la leyenda
  * @param {Function} props.toggleLegend - Función para mostrar/ocultar la leyenda
+ * @param {boolean} props.showLabels - Si se muestran las etiquetas de datos
+ * @param {Function} props.toggleLabels - Función para mostrar/ocultar las etiquetas
  * @param {Function} props.toggleAspectRatio - Función para cambiar la relación de aspecto
  * @param {Function} props.toggleFullscreen - Función para alternar pantalla completa
  * @param {boolean} props.isFullscreen - Si el gráfico está en pantalla completa
@@ -36,6 +37,8 @@ const ChartControls = ({
   resetZoom,
   showLegend,
   toggleLegend,
+  showLabels,
+  toggleLabels,
   toggleAspectRatio,
   toggleFullscreen,
   isFullscreen = false,
@@ -137,6 +140,18 @@ const ChartControls = ({
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            </svg>
+          </button>
+        )}
+
+        {toggleLabels && (
+          <button
+            onClick={toggleLabels}
+            className={`p-1 rounded ${darkMode ? 'hover:bg-gray-700' : 'hover:bg-gray-100'} transition-colors`}
+            title={showLabels ? "Ocultar valores" : "Mostrar valores"}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 6h16M4 12h16M4 18h7" />
             </svg>
           </button>
         )}


### PR DESCRIPTION
## Summary
- fix chart type selector so it doesn't reload to the home page
- allow charts to display relative percentages
- adapt datalabels and tooltips for percentage mode
- forward chart type change from `AnalysisPage`

## Testing
- `npm run lint --prefix frontend` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6850747c6b00832db19fcd58622f2ac9