### PR TITLE
Fix chart not rerendering on variable change

### DIFF
--- a/frontend/src/components/AnalysisPage.jsx
+++ b/frontend/src/components/AnalysisPage.jsx
@@ -481,10 +481,11 @@ export default function AnalysisPage() {
                         <div className={`p-4 rounded-lg ${darkMode ? 'bg-gray-700' : 'bg-gray-50'} mb-4`}>
                           <h4 className="font-medium mb-3">Gráfico</h4>
                           <div className="overflow-hidden chart-container" style={{ maxHeight: 'calc(100vh - 250px)' }}>
-                            <ChartComponent 
-                              variable={selectedVariable.code} 
-                              chartType={chartType} 
-                              sortOrder={sortOrder} 
+                            <ChartComponent
+                              key={selectedVariable.code}
+                              variable={selectedVariable.code}
+                              chartType={chartType}
+                              sortOrder={sortOrder}
                               excludedValues={excludedPrimaryValues}
                               darkMode={darkMode}
                             />
@@ -510,8 +511,9 @@ export default function AnalysisPage() {
                         <div className={`p-4 rounded-lg ${darkMode ? 'bg-gray-700' : 'bg-gray-50'} mb-4`}>
                           <h4 className="font-medium mb-3">Gráfico Bivariado</h4>
                           <div className="overflow-hidden chart-container" style={{ maxHeight: 'calc(100vh - 250px)' }}>
-                            <BivariateChart 
-                              variable1={selectedVariable.code} 
+                            <BivariateChart
+                              key={`${selectedVariable.code}_${secondaryVariable.code}`}
+                              variable1={selectedVariable.code}
                               variable2={secondaryVariable.code}
                               excludedValues1={excludedPrimaryValues}
                               excludedValues2={excludedSecondaryValues}


### PR DESCRIPTION
## Summary
- force `ChartComponent` and `BivariateChart` to remount when variables change by adding unique `key` props

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507e46b084832dbf636f08b68f2c77